### PR TITLE
Set proper paths and libs in run-with-config-args wrapper

### DIFF
--- a/microk8s-resources/wrappers/run-with-config-args
+++ b/microk8s-resources/wrappers/run-with-config-args
@@ -1,5 +1,8 @@
 #!/bin/bash
 set -e
+export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu"
+export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
 
 app=$1
 


### PR DESCRIPTION
This PR adds proper paths to the run-with-config-args wrapper

Dockerd was spawning containerd and was using the locally installed binary (/usr/bin/ in the host). When containerd was removed from the host dockerd was not staring giving this error:
```
May 14 12:03:40 jackal-VGN-FZ11M systemd[1]: snap.microk8s.daemon-docker.service: Main process exited, code=exited, status=1/FAILURE
May 14 12:03:40 jackal-VGN-FZ11M microk8s.daemon-docker[13698]: time="2018-05-14T12:03:39.995163511+03:00" level=debug msg="docker group found. gid: 127"
May 14 12:03:40 jackal-VGN-FZ11M microk8s.daemon-docker[13698]: time="2018-05-14T12:03:39.995822690+03:00" level=debug msg="Listener created for HTTP on unix (/var/snap/microk8s/x1/docker.sock)"
May 14 12:03:40 jackal-VGN-FZ11M microk8s.daemon-docker[13698]: Failed to connect to containerd. Please make sure containerd is installed in your PATH or you have specified the correct address. Got error: exec: 
"containerd": executable file not found in $PATH
```