### PR TITLE
Move the docker profile patch to docker startup

### DIFF
--- a/build-scripts/create-install-hook.sh
+++ b/build-scripts/create-install-hook.sh
@@ -9,15 +9,6 @@ set -eu
 
 cp -r ${SNAP}/default-args ${SNAP_DATA}/args
 
-#TODO(kjackal): Make sure this works everywhere we want
-if [ -f /etc/apparmor.d/docker ]; then
-  echo "Updating docker-default profile"
-  sed 's/^}$/\ \ signal\ (receive)\ peer=snap.microk8s.daemon-docker,\n}/' -i /etc/apparmor.d/docker
-  echo "Reloading AppArmor profiles"
-  service apparmor reload
-  echo "AppArmor patched"
-fi
-
 EOF
 
 chmod +x meta/hooks/install

--- a/build-scripts/create-remove-hook.sh
+++ b/build-scripts/create-remove-hook.sh
@@ -10,7 +10,7 @@ set -eu
 #TODO(kjackal): Make sure this works everywhere we want
 if [ -f /etc/apparmor.d/docker ]; then
   echo "Updating docker-default profile"
-  awk -i inplace '!/^  signal \(receive\) peer=snap.microk8s.daemon-docker,$/ {print}' /etc/apparmor.d/docker
+  gawk -i inplace '!/^  signal \(receive\) peer=snap.microk8s.daemon-docker,$/ {print}' /etc/apparmor.d/docker
   echo "Reloading AppArmor profiles"
   service apparmor reload
   echo "AppArmor patched"

--- a/microk8s-resources/docker-profile
+++ b/microk8s-resources/docker-profile
@@ -1,0 +1,41 @@
+
+
+#include <tunables/global>
+
+
+profile docker-default flags=(attach_disconnected,mediate_deleted) {
+
+  #include <abstractions/base>
+
+
+  network,
+  capability,
+  file,
+  umount,
+
+  deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
+  # deny write to files not in /proc/<number>/** or /proc/sys/**
+  deny @{PROC}/{[^1-9],[^1-9][^0-9],[^1-9s][^0-9y][^0-9s],[^1-9][^0-9][^0-9][^0-9]*}/** w,
+  deny @{PROC}/sys/[^k]** w,  # deny /proc/sys except /proc/sys/k* (effectively /proc/sys/kernel)
+  deny @{PROC}/sys/kernel/{?,??,[^s][^h][^m]**} w,  # deny everything except shm* in /proc/sys/kernel/
+  deny @{PROC}/sysrq-trigger rwklx,
+  deny @{PROC}/mem rwklx,
+  deny @{PROC}/kmem rwklx,
+  deny @{PROC}/kcore rwklx,
+
+  deny mount,
+
+  deny /sys/[^f]*/** wklx,
+  deny /sys/f[^s]*/** wklx,
+  deny /sys/fs/[^c]*/** wklx,
+  deny /sys/fs/c[^g]*/** wklx,
+  deny /sys/fs/cg[^r]*/** wklx,
+  deny /sys/firmware/efi/efivars/** rwklx,
+  deny /sys/kernel/security/** rwklx,
+
+
+  # suppress ptrace denials when using 'docker ps' or using 'ps' inside a container
+  ptrace (trace,read) peer=docker-default,
+
+  signal (receive) peer=snap.microk8s.daemon-docker,
+}

--- a/microk8s-resources/wrappers/run-docker-with-args
+++ b/microk8s-resources/wrappers/run-docker-with-args
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu"
+export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
+
+
+
+#TODO(kjackal): Make sure this works on every distro
+# Until we get a way to properly patch the docker-default profile
+# https://github.com/moby/moby/issues/33060
+if [ -d "/etc/apparmor.d" ]; then
+  # we have AppArmor
+  if [ -f /etc/apparmor.d/docker ]; then
+    # docker default profile exists
+    if ! $(grep -qE "snap.microk8s.daemon-docker" /etc/apparmor.d/docker); then
+      echo "Patching docker-default profile"
+      sed 's/^}$/\ \ signal\ (receive)\ peer=snap.microk8s.daemon-docker,\n}/' -i /etc/apparmor.d/docker
+      echo "Reloading AppArmor profiles"
+      service apparmor reload
+      echo "AppArmor patched"
+    else
+      echo "Docker default profile already patched"
+    fi
+  else
+    echo "Using a docker-default template"
+    cp ${SNAP}/docker-profile /etc/apparmor.d/docker
+    echo "Reloading AppArmor profiles"
+    service apparmor reload
+    echo "AppArmor patched"
+  fi
+fi
+
+app=dockerd
+
+# This is really the only way I could find to get the args passed in correctly. WTF
+declare -a args="($(cat $SNAP_DATA/args/$app))"
+exec "$SNAP/usr/bin/$app" "${args[@]}"

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -16,7 +16,7 @@ apps:
     command: run-with-config-args etcd
     daemon: simple
   daemon-docker:
-    command: run-with-config-args dockerd
+    command: run-docker-with-args
     daemon: simple
   daemon-apiserver:
     command: run-with-config-args kube-apiserver
@@ -52,6 +52,7 @@ parts:
     - conntrack
     - docker.io
     - aufs-tools
+    - gawk
     source: .
     override-build: |
       set -eu
@@ -76,6 +77,9 @@ parts:
       echo "Preparing cni"
       mkdir -p opt/cni/bin/
       cp $KUBE_SNAP_BINS/cni/* opt/cni/bin/
+
+      echo "Preparing dockerd"
+      cp $KUBE_SNAP_ROOT/microk8s-resources/docker-profile .
 
       echo "Preparing etcd"
       cp $KUBE_SNAP_BINS/etcd/etcd .


### PR DESCRIPTION
With this PR we apply the docker-default profile right before we start the docker daemon. We also use a template profile in case it is not already present in /etc/apparmor.d/ .

Docker is discussing means to expose this default profile so we should handle patching it in a more elegant way in the future.