### PR TITLE
Remove exec from actions so actions can be queued

### DIFF
--- a/microk8s-resources/wrappers/microk8s-disable.wrapper
+++ b/microk8s-resources/wrappers/microk8s-disable.wrapper
@@ -6,9 +6,9 @@ export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
 for action in "$@"; do
   # If there is a script to execute for the action $1 run the script and ignore any yamls
   if [ -f "${SNAP}/actions/disable.$action.sh" ]; then
-    exec "${SNAP}/actions/disable.$action.sh"
+    "${SNAP}/actions/disable.$action.sh"
   elif [ -f "${SNAP}/actions/$action.yaml" ]; then
-    exec "$SNAP/kubectl" "--kubeconfig=$SNAP/client.config" "delete" "-f" "${SNAP}/actions/$action.yaml"
+    "$SNAP/kubectl" "--kubeconfig=$SNAP/client.config" "delete" "-f" "${SNAP}/actions/$action.yaml"
   else
     echo "Nothing to do for $action"
   fi

--- a/microk8s-resources/wrappers/microk8s-enable.wrapper
+++ b/microk8s-resources/wrappers/microk8s-enable.wrapper
@@ -6,9 +6,9 @@ export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
 for action in "$@"; do
   # If there is a script to execute for the $action run the script and ignore any yamls
   if [ -f "${SNAP}/actions/enable.$action.sh" ]; then
-    exec "${SNAP}/actions/enable.$action.sh"
+    "${SNAP}/actions/enable.$action.sh"
   elif [ -f "${SNAP}/actions/$action.yaml" ]; then
-    exec "$SNAP/kubectl" "--kubeconfig=$SNAP/client.config" "apply" "-f" "${SNAP}/actions/$action.yaml"
+    "$SNAP/kubectl" "--kubeconfig=$SNAP/client.config" "apply" "-f" "${SNAP}/actions/$action.yaml"
   else
     echo "Nothing to do for $action"
   fi


### PR DESCRIPTION
exec will replace the executing process not leaving the option for another process to spawn. This will not work if we want to queue actions.