### PR TITLE
Remove iptables-xml link

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -62,6 +62,7 @@ parts:
     configflags:
     - "--disable-shared"
     - "--enable-static"
+    prime: [ -bin/iptables-xml ]
   docker:
     after: [iptables]
     plugin: dump


### PR DESCRIPTION
This will remove the iptables-xml from the snap. It should not be needed since it is a utility to turn iptable-save output to xml. This should also allow us to publish to the store without the need for a manual review from the snap store people.