### PR TITLE
Create an alias for microk8s.kubectl

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -35,6 +35,7 @@ apps:
     daemon: simple
   kubectl:
     command: kubectl --kubeconfig=$SNAP/client.config
+    aliases: [kubectl]
   enable:
     command: microk8s-enable.wrapper
   disable:


### PR DESCRIPTION
This makes the UX easier for constant users microk8s it will allow users to, if they opt, alias the command

```
snap alias microk8s kubectl
```