### PR TITLE
Dashboard update with heapster and grafana

### DIFF
--- a/microk8s-resources/actions/dashboard.yaml
+++ b/microk8s-resources/actions/dashboard.yaml
@@ -1,13 +1,34 @@
-apiVersion: extensions/v1beta1
-kind: Deployment
+
+# ------------------- Dashboard ------------------- #
+apiVersion: v1
+kind: Secret
 metadata:
-  name: kubernetes-dashboard
-  namespace: kube-system
   labels:
     k8s-app: kubernetes-dashboard
-    kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
+  name: kubernetes-dashboard-certs
+  namespace: kube-system
+type: Opaque
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard
+  namespace: kube-system
+
+---
+kind: Deployment
+apiVersion: apps/v1beta2
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard
+  namespace: kube-system
 spec:
+  replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       k8s-app: kubernetes-dashboard
@@ -15,48 +36,60 @@ spec:
     metadata:
       labels:
         k8s-app: kubernetes-dashboard
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.6.0
-        resources:
-          # keep request = limit to keep this container in guaranteed class
-          limits:
-            cpu: 100m
-            memory: 50Mi
-          requests:
-            cpu: 100m
-            memory: 50Mi
+        image: k8s.gcr.io/kubernetes-dashboard-amd64:v1.8.3
         ports:
-        - containerPort: 9090
+        - containerPort: 8443
+          protocol: TCP
+        args:
+          - --auto-generate-certificates
+          # Uncomment the following line to manually specify Kubernetes API server Host
+          # If not specified, Dashboard will attempt to auto discover the API server and connect
+          # to it. Uncomment only if the default does not work.
+          # - --apiserver-host=http://my-address:port
+        volumeMounts:
+        - name: kubernetes-dashboard-certs
+          mountPath: /certs
+          # Create on-disk volume to store exec logs
+        - mountPath: /tmp
+          name: tmp-volume
         livenessProbe:
           httpGet:
+            scheme: HTTPS
             path: /
-            port: 9090
+            port: 8443
           initialDelaySeconds: 30
           timeoutSeconds: 30
+      volumes:
+      - name: kubernetes-dashboard-certs
+        secret:
+          secretName: kubernetes-dashboard-certs
+      - name: tmp-volume
+        emptyDir: {}
+      serviceAccountName: kubernetes-dashboard
+      # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
-      - key: "CriticalAddonsOnly"
-        operator: "Exists"
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+
 ---
-apiVersion: v1
 kind: Service
+apiVersion: v1
 metadata:
-  name: kubernetes-dashboard
-  namespace: kube-system
   labels:
     k8s-app: kubernetes-dashboard
-    kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
+  name: kubernetes-dashboard
+  namespace: kube-system
 spec:
+  ports:
+    - port: 443
+      targetPort: 8443
   selector:
     k8s-app: kubernetes-dashboard
-  ports:
-  - port: 80
-    targetPort: 9090
 ---
+# ------------------ Monitoring (heapster,influxdb, grafana) ----------- #
 apiVersion: v1
 kind: Service
 metadata:
@@ -72,12 +105,49 @@ spec:
   # type: LoadBalancer
   ports:
     - port: 80
-      targetPort: 3000
+      protocol: TCP
+      targetPort: ui
   selector:
     k8s-app: influxGrafana
 ---
 apiVersion: v1
-kind: ReplicationController
+kind: Service
+metadata:
+  name: monitoring-influxdb
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    kubernetes.io/name: "InfluxDB"
+spec:
+  ports:
+    - name: http
+      port: 8083
+      targetPort: 8083
+    - name: api
+      port: 8086
+      targetPort: 8086
+  selector:
+    k8s-app: influxGrafana
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: heapster
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    kubernetes.io/name: "Heapster"
+spec:
+  ports:
+    - port: 80
+      targetPort: 8082
+  selector:
+    k8s-app: heapster
+---
+kind: Deployment
+apiVersion: extensions/v1beta1
 metadata:
   name: monitoring-influxdb-grafana-v4
   namespace: kube-system
@@ -89,20 +159,27 @@ metadata:
 spec:
   replicas: 1
   selector:
-    k8s-app: influxGrafana
-    version: v4
+    matchLabels:
+      k8s-app: influxGrafana
+      version: v4
   template:
     metadata:
       labels:
         k8s-app: influxGrafana
         version: v4
-        kubernetes.io/cluster-service: "true"
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      priorityClassName: system-cluster-critical
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      - key: "CriticalAddonsOnly"
+        operator: "Exists"
       containers:
-        - image: gcr.io/google_containers/heapster-influxdb-amd64:v1.1.1
-          name: influxdb
+        - name: influxdb
+          image: k8s.gcr.io/heapster-influxdb-amd64:v1.3.3
           resources:
-            # keep request = limit to keep this container in guaranteed class
             limits:
               cpu: 100m
               memory: 500Mi
@@ -110,13 +187,15 @@ spec:
               cpu: 100m
               memory: 500Mi
           ports:
-            - containerPort: 8083
-            - containerPort: 8086
+            - name: http
+              containerPort: 8083
+            - name: api
+              containerPort: 8086
           volumeMounts:
           - name: influxdb-persistent-storage
             mountPath: /data
-        - image: gcr.io/google_containers/heapster-grafana-amd64:v4.0.2
-          name: grafana
+        - name: grafana
+          image: k8s.gcr.io/heapster-grafana-amd64:v4.4.3
           env:
           resources:
             # keep request = limit to keep this container in guaranteed class
@@ -141,7 +220,10 @@ spec:
             - name: GF_AUTH_ANONYMOUS_ORG_ROLE
               value: Admin
             - name: GF_SERVER_ROOT_URL
-              value: /api/v1/proxy/namespaces/kube-system/services/monitoring-grafana/
+              value: /api/v1/namespaces/kube-system/services/monitoring-grafana/proxy/
+          ports:
+          - name: ui
+            containerPort: 3000
           volumeMounts:
           - name: grafana-persistent-storage
             mountPath: /var
@@ -150,25 +232,161 @@ spec:
         emptyDir: {}
       - name: grafana-persistent-storage
         emptyDir: {}
-
 ---
 apiVersion: v1
-kind: Service
+kind: ServiceAccount
 metadata:
-  name: monitoring-influxdb
+  name: heapster
   namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    kubernetes.io/name: "InfluxDB"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: heapster-config
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: EnsureExists
+data:
+  NannyConfiguration: |-
+    apiVersion: nannyconfig/v1alpha1
+    kind: NannyConfiguration
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: eventer-config
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: EnsureExists
+data:
+  NannyConfiguration: |-
+    apiVersion: nannyconfig/v1alpha1
+    kind: NannyConfiguration
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: heapster-v1.5.2
+  namespace: kube-system
+  labels:
+    k8s-app: heapster
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    version: v1.5.2
 spec:
-  ports:
-    - name: http
-      port: 8083
-      targetPort: 8083
-    - name: api
-      port: 8086
-      targetPort: 8086
+  replicas: 1
   selector:
-    k8s-app: influxGrafana
-
+    matchLabels:
+      k8s-app: heapster
+      version: v1.5.2
+  template:
+    metadata:
+      labels:
+        k8s-app: heapster
+        version: v1.5.2
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      priorityClassName: system-cluster-critical
+      containers:
+        - image: k8s.gcr.io/heapster-amd64:v1.5.2
+          name: heapster
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8082
+              scheme: HTTP
+            initialDelaySeconds: 180
+            timeoutSeconds: 5
+          command:
+            - /heapster
+            - --source=kubernetes.summary_api:''
+            - --sink=influxdb:http://monitoring-influxdb:8086
+        - image: k8s.gcr.io/heapster-amd64:v1.5.2
+          name: eventer
+          command:
+            - /eventer
+            - --source=kubernetes:''
+            - --sink=influxdb:http://monitoring-influxdb:8086
+        - image: k8s.gcr.io/addon-resizer:1.8.1
+          name: heapster-nanny
+          resources:
+            limits:
+              cpu: 50m
+              memory: 92360Ki
+            requests:
+              cpu: 50m
+              memory: 92360Ki
+          env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+          - name: heapster-config-volume
+            mountPath: /etc/config
+          command:
+            - /pod_nanny
+            - --config-dir=/etc/config
+            - --cpu=80m
+            - --extra-cpu=0.5m
+            - --memory=140Mi
+            - --extra-memory=4Mi
+            - --threshold=5
+            - --deployment=heapster-v1.5.2
+            - --container=heapster
+            - --poll-period=300000
+            - --estimator=exponential
+        - image: k8s.gcr.io/addon-resizer:1.8.1
+          name: eventer-nanny
+          resources:
+            limits:
+              cpu: 50m
+              memory: 92360Ki
+            requests:
+              cpu: 50m
+              memory: 92360Ki
+          env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+          - name: eventer-config-volume
+            mountPath: /etc/config
+          command:
+            - /pod_nanny
+            - --config-dir=/etc/config
+            - --cpu=100m
+            - --extra-cpu=0m
+            - --memory=190Mi
+            - --extra-memory=500Ki
+            - --threshold=5
+            - --deployment=heapster-v1.5.2
+            - --container=eventer
+            - --poll-period=300000
+            - --estimator=exponential
+      volumes:
+        - name: heapster-config-volume
+          configMap:
+            name: heapster-config
+        - name: eventer-config-volume
+          configMap:
+            name: eventer-config
+      serviceAccountName: heapster
+      tolerations:
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"


### PR DESCRIPTION
This PR enables graphs on the dashboard and grafana. To access grafana just `microk8s.kubectl cluster-info` and click the grafana link.