### PR TITLE
Adding addon tests and testing in trusty/travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ script:
   - sudo apt update
   - sudo apt install --yes snapd
   - sudo snap install *.snap --classic --dangerous
-  - sleep 10
   - sudo pip install -U pytest
   - pwd
   - ps -ef

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,11 @@ script:
   - sudo apt update
   - sudo apt install --yes snapd
   - sudo snap install *.snap --classic --dangerous
+  - sleep 10
+  - sudo pip install -U pytest
   - pwd
+  - ps -ef
   - ls -l
   - ./tests/smoke-test.sh
+  - (cd tests; pytest -s test-addons.py)
   - sudo snap remove microk8s
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,5 @@ script:
   - ls -l
   - ./tests/smoke-test.sh
   - (cd tests; pytest -s test-addons.py)
+  - sudo microk8s.reset
   - sudo snap remove microk8s

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ snap enable microk8s
 
 ### Removing microk8s
 
-To remove microk8s we recommend you first disable all addons and stop all hosted pods. microk8s.reset can assist with that.
+Before removing microk8s, use `microk8s.reset` to stop all running pods.
 
 ```
 microk8s.reset

--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ microk8s can be restarted later with the snap command
 snap enable microk8s
 ```
 
+### Removing microk8s
+
+To remove microk8s we recommend you first disable all addons and stop all hosted pods. microk8s.reset can assist with that.
+
+```
+microk8s.reset
+snap remove microk8s
+```
 
 ### Configuring microk8s services
 The following systemd services will be running in your system:

--- a/microk8s-resources/actions/disable.dns.sh
+++ b/microk8s-resources/actions/disable.dns.sh
@@ -2,17 +2,18 @@
 
 set -e
 
-## remove an option inside the config file.
 skip_opt_in_config() {
+    # remove an option inside the config file.
+    # argument $1 is the option to be removed
+    # argument $2 is the configuration file under $SNAP_DATA/args
     opt="--$1"
     config_file="$SNAP_DATA/args/$2"
-    sudo AWKLIBPATH="${SNAP}/usr/lib/x86_64-linux-gnu/gawk" AWKPATH="${SNAP}/usr/share/awk/" \
-      "${SNAP}/usr/bin/gawk" -i inplace '!/^'"$opt"'/ {print $0}' "${config_file}"
+    sudo "${SNAP}/bin/sed" -i '/'"$opt"'/d' "${config_file}"
 }
 
 echo "Disabling DNS"
 echo "Reconfiguring kubelet"
-#TODO(kjackal): do not hardcode the info below. Get it from the yaml
+
 skip_opt_in_config "cluster-domain" kubelet
 skip_opt_in_config "cluster-dns" kubelet
 sudo systemctl restart snap.${SNAP_NAME}.daemon-kubelet

--- a/microk8s-resources/actions/disable.dns.sh
+++ b/microk8s-resources/actions/disable.dns.sh
@@ -6,7 +6,8 @@ set -e
 skip_opt_in_config() {
     opt="--$1"
     config_file="$SNAP_DATA/args/$2"
-    sudo gawk -i inplace '!/^'"$opt"'/ {print $0}' "${config_file}"
+    sudo AWKLIBPATH="${SNAP}/usr/lib/x86_64-linux-gnu/gawk" AWKPATH="${SNAP}/usr/share/awk/" \
+      "${SNAP}/usr/bin/gawk" -i inplace '!/^'"$opt"'/ {print $0}' "${config_file}"
 }
 
 echo "Disabling DNS"

--- a/microk8s-resources/actions/disable.storage.sh
+++ b/microk8s-resources/actions/disable.storage.sh
@@ -4,7 +4,7 @@ set -e
 
 echo "Disabling default storage"
 cat "${SNAP}/actions/storage.yaml" | \
-sed 's@\$SNAP_COMMON@'"$SNAP_COMMON"'@g' | \
+"$SNAP/bin/sed" 's@\$SNAP_COMMON@'"$SNAP_COMMON"'@g' | \
 "$SNAP/kubectl" "--kubeconfig=$SNAP/client.config" delete -f -
 sleep 5
 echo "Storage removed"

--- a/microk8s-resources/actions/enable.dns.sh
+++ b/microk8s-resources/actions/enable.dns.sh
@@ -9,9 +9,9 @@ refresh_opt_in_config() {
     config_file="$SNAP_DATA/args/$3"
     replace_line="$opt=$value"
     if $(grep -qE "^$opt=" $config_file); then
-        sudo sed -i "s/^$opt=.*/$replace_line/" $config_file
+        sudo "$SNAP/bin/sed" -i "s/^$opt=.*/$replace_line/" $config_file
     else
-        sudo sed -i "$ a $replace_line" "$config_file"
+        sudo "$SNAP/bin/sed" -i "$ a $replace_line" "$config_file"
     fi
 }
 

--- a/microk8s-resources/actions/enable.storage.sh
+++ b/microk8s-resources/actions/enable.storage.sh
@@ -5,6 +5,6 @@ set -e
 echo "Enabling default storage class"
 sudo mkdir -p ${SNAP_COMMON}/default-storage
 cat "${SNAP}/actions/storage.yaml" | \
-sed 's@\$SNAP_COMMON@'"$SNAP_COMMON"'@g' | \
+"$SNAP/bin/sed" 's@\$SNAP_COMMON@'"$SNAP_COMMON"'@g' | \
 "$SNAP/kubectl" "--kubeconfig=$SNAP/client.config" apply -f -
 echo "Storage will be available soon"

--- a/microk8s-resources/default-args/kube-proxy
+++ b/microk8s-resources/default-args/kube-proxy
@@ -1,3 +1,4 @@
 --master='http://127.0.0.1:8080'
 --cluster-cidr=10.152.183.0/24
 --kubeconfig=${SNAP}/kubeproxy.config
+--proxy-mode="userspace"

--- a/microk8s-resources/wrappers/microk8s-config.wrapper
+++ b/microk8s-resources/wrappers/microk8s-config.wrapper
@@ -36,6 +36,6 @@ if [[ "$USE_LOOPBACK" == "true" ]]; then
     cat "$SNAP/client.config"
 else
     DEFAULT_INTERFACE="$(netstat -rn | grep '^0.0.0.0' | awk '{print $NF}')"
-    IP_ADDR="$(ifconfig "$DEFAULT_INTERFACE" | grep 'inet ' | awk '{print $2}' | sed -e 's/addr://')"
-    sed -e "s/127.0.0.1/$IP_ADDR/" "$SNAP/client.config"
+    IP_ADDR="$(ifconfig "$DEFAULT_INTERFACE" | grep 'inet ' | "$SNAP/usr/bin/gawk" '{print $2}' | "$SNAP/bin/sed" -e 's/addr://')"
+    "$SNAP/bin/sed" -e "s/127.0.0.1/$IP_ADDR/" "$SNAP/client.config"
 fi

--- a/microk8s-resources/wrappers/microk8s-reset.wrapper
+++ b/microk8s-resources/wrappers/microk8s-reset.wrapper
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -eu
+
+clean_cluster() {
+  echo "Calling clean_cluster"
+  # Clean the cluster
+  NSES=$(/snap/bin/microk8s.kubectl get ns -o=custom-columns="NAME:metadata.name" --no-headers 2>&1 | tr '\n' ' ')
+  for NS in $NSES
+  do
+    echo "Cleaning service, deployments and pods in namespace $NS"
+    # delete all services
+    /snap/bin/microk8s.kubectl delete --all services --namespace="$NS" 2>&1 > /dev/null
+    # delete all deployments
+    /snap/bin/microk8s.kubectl delete --all deployments --namespace="$NS" 2>&1 > /dev/null
+    # delete all pods
+    /snap/bin/microk8s.kubectl delete --all pods --namespace="$NS" 2>&1 > /dev/null
+  done
+
+  # Wait for 200 secs at most.
+  echo "Waiting for kubernetes resources to be released"
+  n=0
+  until [ $n -ge 10 ]
+  do
+    (/snap/bin/microk8s.kubectl get po --all-namespaces 2>&1 | grep "No resources found." 2>&1 > /dev/null) && break
+    n=$[$n+1]
+    sleep 20
+  done
+}
+
+
+clean_cluster

--- a/microk8s-resources/wrappers/run-docker-with-args
+++ b/microk8s-resources/wrappers/run-docker-with-args
@@ -15,7 +15,7 @@ if [ -d "/etc/apparmor.d" ]; then
     # docker default profile exists
     if ! $(grep -qE "snap.microk8s.daemon-docker" /etc/apparmor.d/docker); then
       echo "Patching docker-default profile"
-      sed 's/^}$/\ \ signal\ (receive)\ peer=snap.microk8s.daemon-docker,\n}/' -i /etc/apparmor.d/docker
+      "$SNAP/bin/sed" 's/^}$/\ \ signal\ (receive)\ peer=snap.microk8s.daemon-docker,\n}/' -i /etc/apparmor.d/docker
       echo "Reloading AppArmor profiles"
       service apparmor reload
       echo "AppArmor patched"

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -12,12 +12,12 @@ then
   echo "Patching certificates location"
   mkdir -p ${SNAP_DATA}/certs
   cp -r ${SNAP}/certs-beta/* ${SNAP_DATA}/certs/
-  sed -i 's@\${SNAP}/certs/ca.crt@\${SNAP_DATA}/certs/ca.crt@g' ${SNAP_DATA}/args/kube-apiserver
-  sed -i 's@\${SNAP}/certs/server.key@\${SNAP_DATA}/certs/server.key@g' ${SNAP_DATA}/args/kube-apiserver
-  sed -i 's@\${SNAP}/certs/server.crt@\${SNAP_DATA}/certs/server.crt@g' ${SNAP_DATA}/args/kube-apiserver
-  sed -i 's@\${SNAP}/certs/serviceaccount.key@\${SNAP_DATA}/certs/serviceaccount.key@g' ${SNAP_DATA}/args/kube-apiserver
-  sed -i 's@\${SNAP}/certs/ca.crt@\${SNAP_DATA}/certs/ca.crt@g' ${SNAP_DATA}/args/kube-controller-manager
-  sed -i 's@\${SNAP}/certs/serviceaccount.key@\${SNAP_DATA}/certs/serviceaccount.key@g' ${SNAP_DATA}/args/kube-controller-manager
+  "$SNAP/bin/sed" -i 's@\${SNAP}/certs/ca.crt@\${SNAP_DATA}/certs/ca.crt@g' ${SNAP_DATA}/args/kube-apiserver
+  "$SNAP/bin/sed" -i 's@\${SNAP}/certs/server.key@\${SNAP_DATA}/certs/server.key@g' ${SNAP_DATA}/args/kube-apiserver
+  "$SNAP/bin/sed" -i 's@\${SNAP}/certs/server.crt@\${SNAP_DATA}/certs/server.crt@g' ${SNAP_DATA}/args/kube-apiserver
+  "$SNAP/bin/sed" -i 's@\${SNAP}/certs/serviceaccount.key@\${SNAP_DATA}/certs/serviceaccount.key@g' ${SNAP_DATA}/args/kube-apiserver
+  "$SNAP/bin/sed" -i 's@\${SNAP}/certs/ca.crt@\${SNAP_DATA}/certs/ca.crt@g' ${SNAP_DATA}/args/kube-controller-manager
+  "$SNAP/bin/sed" -i 's@\${SNAP}/certs/serviceaccount.key@\${SNAP_DATA}/certs/serviceaccount.key@g' ${SNAP_DATA}/args/kube-controller-manager
   systemctl restart snap.${SNAP_NAME}.daemon-apiserver
   systemctl restart snap.${SNAP_NAME}.daemon-controller-manager
 fi

--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -eu
 
+export AWKLIBPATH="${SNAP}/usr/lib/x86_64-linux-gnu/gawk"
+export AWKPATH="${SNAP}/usr/share/awk/"
+
 snapctl stop ${SNAP_NAME}.daemon-kubelet 2>&1 || true
 snapctl stop ${SNAP_NAME}.daemon-docker 2>&1 || true
 mount | grep ${SNAP_COMMON}/pods | cut -d ' ' -f 3 | xargs umount
@@ -9,7 +12,7 @@ mount | grep ${SNAP_COMMON}/var/*/docker | cut -d ' ' -f 3 | xargs umount
 #TODO(kjackal): Make sure this works everywhere we want
 if [ -f /etc/apparmor.d/docker ]; then
   echo "Updating docker-default profile"
-  gawk -i inplace '!/^  signal \(receive\) peer=snap.microk8s.daemon-docker,$/ {print}' /etc/apparmor.d/docker
+  "${SNAP}/usr/bin/gawk" -i inplace '!/^  signal \(receive\) peer=snap.microk8s.daemon-docker,$/ {print}' /etc/apparmor.d/docker
   echo "Reloading AppArmor profiles"
   service apparmor reload
   echo "AppArmor patched"

--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 set -eu
 
-export AWKLIBPATH="${SNAP}/usr/lib/x86_64-linux-gnu/gawk"
-export AWKPATH="${SNAP}/usr/share/awk/"
-
 snapctl stop ${SNAP_NAME}.daemon-kubelet 2>&1 || true
 snapctl stop ${SNAP_NAME}.daemon-docker 2>&1 || true
 mount | grep ${SNAP_COMMON}/pods | cut -d ' ' -f 3 | xargs umount
@@ -12,7 +9,7 @@ mount | grep ${SNAP_COMMON}/var/*/docker | cut -d ' ' -f 3 | xargs umount
 #TODO(kjackal): Make sure this works everywhere we want
 if [ -f /etc/apparmor.d/docker ]; then
   echo "Updating docker-default profile"
-  "${SNAP}/usr/bin/gawk" -i inplace '!/^  signal \(receive\) peer=snap.microk8s.daemon-docker,$/ {print}' /etc/apparmor.d/docker
+  "${SNAP}/bin/sed" -i '/  signal (receive) peer=snap.microk8s.daemon-docker,/d' /etc/apparmor.d/docker
   echo "Reloading AppArmor profiles"
   service apparmor reload
   echo "AppArmor patched"

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -73,6 +73,7 @@ parts:
     - docker.io
     - aufs-tools
     - gawk
+    - sed
     source: .
     stage:
     - -sbin/xtables-multi
@@ -87,6 +88,8 @@ parts:
     - curl
     - openssl
     - file
+    stage-packages:
+    - util-linux
     source: .
     override-build: |
       set -eu

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -41,6 +41,8 @@ apps:
     command: microk8s-disable.wrapper
   config:
     command: microk8s-config.wrapper
+  reset:
+    command: microk8s-reset.wrapper
 
 parts:
   libnftnl:

--- a/tests/smoke-test.sh
+++ b/tests/smoke-test.sh
@@ -3,7 +3,6 @@
 
 set -eux
 
-sleep 30
 n=0
 until [ $n -ge 10 ]
 do

--- a/tests/smoke-test.sh
+++ b/tests/smoke-test.sh
@@ -7,7 +7,18 @@ sleep 30
 n=0
 until [ $n -ge 10 ]
 do
-  (/snap/bin/microk8s.kubectl get all --all-namespaces | grep -z "service/kubernetes") && exit 0
+  (/snap/bin/microk8s.kubectl get all --all-namespaces | grep -z "service/kubernetes") && break
+  n=$[$n+1]
+  if [ $n -ge 10 ]; then
+    exit 1
+  fi
+  sleep 20
+done
+
+n=0
+until [ $n -ge 3 ]
+do
+  (/snap/bin/microk8s.kubectl get no | grep -z "Ready") && exit 0
   n=$[$n+1]
   sleep 20
 done

--- a/tests/templates/bbox.yaml
+++ b/tests/templates/bbox.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  namespace: default
+spec:
+  containers:
+  - name: busybox
+    image: busybox
+    command:
+      - sleep
+      - "3600"
+    imagePullPolicy: IfNotPresent
+  restartPolicy: Always

--- a/tests/templates/pvc.yaml
+++ b/tests/templates/pvc.yaml
@@ -1,0 +1,11 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: myclaim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 8Gi

--- a/tests/test-addons.py
+++ b/tests/test-addons.py
@@ -1,0 +1,53 @@
+from validators import validate_dns, validate_dashboard, validate_storage
+from utils import microk8s_enable, wait_for_pod_state, microk8s_disable
+from subprocess import Popen, PIPE, STDOUT
+
+class TestAddons(object):
+
+    def test_dns(self):
+        """
+        Sets up DNS addon and validates it works.
+
+        """
+        print("Enabling DNS")
+        microk8s_enable("dns")
+        wait_for_pod_state("", "kube-system", "running", label="k8s-app=kube-dns")
+        # Create a bbox
+        print("Validating dns")
+        validate_dns()
+        print("Disabling DNS")
+        microk8s_disable("dns")
+
+    def test_dashboard(self):
+        """
+        Sets up dashboard and validates it works.
+
+        """
+        print("Enabling DNS")
+        microk8s_enable("dns")
+        wait_for_pod_state("", "kube-system", "running", label="k8s-app=kube-dns")
+        print("Enabling dashboard")
+        microk8s_enable("dashboard")
+        print("Validating dashboard")
+        validate_dashboard()
+        print("Disabling DNS")
+        microk8s_disable("dns")
+        print("Disabling dashboard")
+        microk8s_disable("dashboard")
+
+    def test_storage(self):
+        """
+        Sets up storage addon and validates it works.
+
+        """
+        print("Enabling DNS")
+        microk8s_enable("dns")
+        print("Enabling storage")
+        microk8s_enable("storage")
+        print("Validating storage")
+        validate_storage()
+        print("Disabling storage")
+        p = Popen("/snap/bin/microk8s.disable storage".split(), stdout=PIPE, stdin=PIPE, stderr=STDOUT)
+        disable = p.communicate(input=b'Y')[0]
+        print("Disabling DNS")
+        microk8s_disable("dns")

--- a/tests/test-live-addons.py
+++ b/tests/test-live-addons.py
@@ -1,0 +1,32 @@
+from validators import validate_dns, validate_dashboard, validate_storage
+from utils import microk8s_enable, wait_for_pod_state, microk8s_disable
+from subprocess import Popen, PIPE, STDOUT
+
+class TestLiveAddons(object):
+    """
+    Validates a microk8s with all the addons enabled
+    """
+
+    def test_dns(self):
+        """
+        Validates DNS works.
+
+        """
+        wait_for_pod_state("", "kube-system", "running", label="k8s-app=kube-dns")
+        # Create a bbox
+        validate_dns()
+
+    def test_dashboard(self):
+        """
+        Validates dashboards works.
+
+        """
+        wait_for_pod_state("", "kube-system", "running", label="k8s-app=kube-dns")
+        validate_dashboard()
+
+    def test_storage(self):
+        """
+        Validates storage works.
+
+        """
+        validate_storage()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,105 @@
+import datetime
+import time
+import yaml
+from subprocess import check_output, CalledProcessError
+
+
+def run_until_success(cmd, timeout_insec=300):
+    """
+    Run a command untill it succeeds or times out.
+    Args:
+        cmd: Command to run
+        timeout_insec: Time out in seconds
+
+    Returns: The string output of the command
+
+    """
+    deadline = datetime.datetime.now() + datetime.timedelta(seconds=timeout_insec)
+    while True:
+        try:
+            output = check_output(cmd.split()).strip().decode('utf8')
+            return output.replace('\\n', '\n')
+        except CalledProcessError:
+            if datetime.datetime.now() > deadline:
+                raise
+            print("Retrying {}".format(cmd))
+            time.sleep(3)
+
+
+def kubectl(cmd):
+    """
+    Do a kubectl <cmd>
+    Args:
+        cmd: left part of kubectl <left_part> command
+
+    Returns: the kubectl response in a string
+
+    """
+    cmd = '/snap/bin/microk8s.kubectl ' + cmd
+    return run_until_success(cmd)
+
+
+def kubectl_get(target):
+    """
+    Do a kubectl get and return the results in a yaml structure.
+    Args:
+        target: which resource we are getting
+
+    Returns: YAML structured response
+
+    """
+    cmd = 'get -o yaml ' + target
+    output = kubectl(cmd)
+    return yaml.load(output)
+
+
+def wait_for_pod_state(pod, namespace, desired_state, desired_reason=None, label=None):
+    """
+    Wait for a a pod state. If you do not specify a pod name and you set instead a label
+    only the first pod will be checked.
+    """
+    while True:
+        cmd = 'po {} -n {}'.format(pod, namespace)
+        if label:
+            cmd += ' -l {}'.format(label)
+        data = kubectl_get(cmd)
+        if pod == "":
+            status = data['items'][0]['status']
+        else:
+            status = data['status']
+        if 'containerStatuses' in status:
+            container_status = status['containerStatuses'][0]
+            state, details = list(container_status['state'].items())[0]
+            if desired_reason:
+                reason = details.get('reason')
+                if state == desired_state and reason == desired_reason:
+                    break
+            elif state == desired_state:
+                break
+        time.sleep(3)
+
+
+def microk8s_enable(addon):
+    """
+    Disable an addon
+
+    Args:
+        addon: name of the addon
+
+    """
+    cmd = '/snap/bin/microk8s.enable {}'.format(addon)
+    time.sleep(10)
+    return run_until_success(cmd)
+
+
+def microk8s_disable(addon):
+    """
+    Enable an addon
+
+    Args:
+        addon: name of the addon
+
+    """
+    cmd = '/snap/bin/microk8s.disable {}'.format(addon)
+    time.sleep(10)
+    return run_until_success(cmd)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -88,7 +88,6 @@ def microk8s_enable(addon):
 
     """
     cmd = '/snap/bin/microk8s.enable {}'.format(addon)
-    time.sleep(10)
     return run_until_success(cmd)
 
 
@@ -101,5 +100,4 @@ def microk8s_disable(addon):
 
     """
     cmd = '/snap/bin/microk8s.disable {}'.format(addon)
-    time.sleep(10)
     return run_until_success(cmd)

--- a/tests/validators.py
+++ b/tests/validators.py
@@ -1,0 +1,57 @@
+import time
+import os
+import requests
+
+from utils import kubectl, wait_for_pod_state
+
+
+def validate_dns():
+    """
+    Validate DNS by starting a busy box and nslookuping the kubernetes default service.
+    """
+    here = os.path.dirname(os.path.abspath(__file__))
+    manifest = os.path.join(here, "templates", "bbox.yaml")
+    kubectl("apply -f {}".format(manifest))
+    wait_for_pod_state("busybox", "default", "running")
+    output = kubectl("exec -ti busybox -- nslookup kubernetes.default.svc.cluster.local")
+    assert "10.152.183.1" in output
+    kubectl("delete -f {}".format(manifest))
+
+
+def validate_dashboard():
+    """
+    Validate the dashboard addon by looking at the grafana URL.
+    """
+    wait_for_pod_state("", "kube-system", "running", label="k8s-app=influxGrafana")
+    cluster_info = kubectl("cluster-info")
+    grafana_url = "http://127.0.0.1:8080/api/v1/namespaces/kube-system/services/monitoring-grafana/proxy"
+    assert grafana_url in cluster_info
+    attempt = 5
+    while attempt >= 0:
+        resp = requests.get(grafana_url)
+        if resp.status_code == 200:
+            break
+        time.sleep(20)
+        attempt -= 1
+    assert resp.status_code == 200
+
+
+def validate_storage():
+    """
+    Validate storage by creating a PVC.
+    """
+    wait_for_pod_state("", "kube-system", "running", label="app=nfs-provisioner")
+    here = os.path.dirname(os.path.abspath(__file__))
+    manifest = os.path.join(here, "templates", "pvc.yaml")
+    kubectl("apply -f {}".format(manifest))
+
+    attempt = 5
+    while attempt >= 0:
+        output = kubectl("get pvc")
+        if "Bound" in output:
+            break
+        time.sleep(20)
+        attempt -= 1
+
+    assert "myclaim" in output
+    assert "Bound" in output


### PR DESCRIPTION
A basic set of test, one for each addon we have. We can call the "validators" on a running microk8s by either enabling/disabling the addons or expecting the addons to be already there. The later case will be used when working on testing the upgrade paths.

A few fixes that were made while testing on travis (trusty).
-  util-linux are needed by kubenet
- sed needed to be installed
- gawk should be the one we package. 

Also adding a reset command to clean pods. Should be used before removing snap. Fixes: https://github.com/juju-solutions/microk8s/issues/23