### PR TITLE
Upgrade test linked to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ script:
   - (cd tests; pytest -s test-addons.py)
   - sudo microk8s.reset
   - sudo snap remove microk8s
-  - UPGRADE_MICROK8S_FROM=edge UPGRADE_MICROK8S_TO=`pwd`/*.snap pytest -s ./tests/test-upgrade.py
+  - UPGRADE_MICROK8S_FROM=edge UPGRADE_MICROK8S_TO=`pwd`/`ls microk8s*.snap` pytest -s ./tests/test-upgrade.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,4 @@ script:
   - (cd tests; pytest -s test-addons.py)
   - sudo microk8s.reset
   - sudo snap remove microk8s
+  - UPGRADE_MICROK8S_FROM=edge UPGRADE_MICROK8S_TO=`pwd`/*.snap pytest -s ./tests/test-upgrade.py

--- a/tests/test-upgrade.py
+++ b/tests/test-upgrade.py
@@ -1,0 +1,82 @@
+import os
+import time
+from validators import validate_dns, validate_dashboard, validate_storage, validate_ingress
+from subprocess import check_call
+from utils import microk8s_enable, wait_for_pod_state, microk8s_disable, wait_for_installation
+
+upgrade_from = os.environ.get('UPGRADE_MICROK8S_FROM', 'beta')
+# Have UPGRADE_MICROK8S_TO point to a file to upgrade to that file
+upgrade_to = os.environ.get('UPGRADE_MICROK8S_TO', 'edge')
+
+
+class TestUpgrade(object):
+    """
+    Validates a microk8s upgrade path
+    """
+
+    def test_upgrade(self):
+        """
+        Deploy, probe, upgrade, validate nothing broke.
+
+        """
+        cmd = "sudo snap install microk8s --classic --{}".format(upgrade_from).split()
+        check_call(cmd)
+        wait_for_installation()
+
+        # Run through the validators and
+        # select those that were valid for the original snap
+        test_matrix = {}
+        try:
+            microk8s_enable("dns")
+            wait_for_pod_state("", "kube-system", "running", label="k8s-app=kube-dns")
+            validate_dns()
+            test_matrix['dns'] = validate_dns
+        except:
+            print('Will not test dns')
+
+        try:
+            microk8s_enable("dashboard")
+            validate_dashboard()
+            test_matrix['dashboard'] = validate_dashboard
+        except:
+            print('Will not test dashboard')
+
+        try:
+            microk8s_enable("storage")
+            validate_storage()
+            test_matrix['storage'] = validate_storage
+        except:
+            print('Will not test storage')
+
+        try:
+            microk8s_enable("ingress")
+            validate_ingress()
+            test_matrix['ingress'] = validate_ingress
+        except:
+            print('Will not test ingress')
+
+        # Refresh the snap to the target
+        if upgrade_to.endswith('.snap'):
+            cmd = "sudo snap install {} --classic --dangerous".format(upgrade_to).split()
+        else:
+            cmd = "sudo snap refresh microk8s --{}".format(upgrade_to).split()
+        check_call(cmd)
+        # Allow for the refresh to be processed
+        time.sleep(10)
+        wait_for_installation()
+
+        # Test any validations that were valid for the original snap
+        for test, validation in test_matrix.items():
+            print("Testing {}".format(test))
+            validation()
+
+        # Cleanup
+        for test, _ in test_matrix.items():
+            microk8s_disable(test)
+
+        # Allow for addons to be removed
+        time.sleep(30)
+
+        cmd = "sudo snap remove microk8s".split()
+        check_call(cmd)
+

--- a/tests/test-upgrade.py
+++ b/tests/test-upgrade.py
@@ -19,6 +19,8 @@ class TestUpgrade(object):
         Deploy, probe, upgrade, validate nothing broke.
 
         """
+        print("Testing upgrade from {} to {}".format(upgrade_from, upgrade_to))
+
         cmd = "sudo snap install microk8s --classic --{}".format(upgrade_from).split()
         check_call(cmd)
         wait_for_installation()

--- a/tests/test-upgrade.py
+++ b/tests/test-upgrade.py
@@ -70,13 +70,5 @@ class TestUpgrade(object):
             print("Testing {}".format(test))
             validation()
 
-        # Cleanup
-        for test, _ in test_matrix.items():
-            microk8s_disable(test)
-
-        # Allow for addons to be removed
-        time.sleep(30)
-
         cmd = "sudo snap remove microk8s".split()
         check_call(cmd)
-

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -79,6 +79,22 @@ def wait_for_pod_state(pod, namespace, desired_state, desired_reason=None, label
         time.sleep(3)
 
 
+def wait_for_installation():
+    """
+    Wait for kubernetes service to appear.
+    """
+    while True:
+        cmd = 'svc kubernetes'
+        data = kubectl_get(cmd)
+        service = data['metadata']['name']
+        if 'kubernetes' in service:
+            break
+        else:
+            time.sleep(3)
+    # Allow rest of the services to come up
+    time.sleep(30)
+
+
 def microk8s_enable(addon):
     """
     Disable an addon


### PR DESCRIPTION
This PR adds a test to verify that the upgrade of a snap is not broken.
We first deploy the snap from UPGRADE_MICROK8S_FROM channel. Then we go through the validators to see which ones apply for that charm. We then upgrade to UPGRADE_MICROK8S_TO and we need the same validators to be passing.

The upgrade path that is tested is the one on the edge channel (see travis.yaml) and eventually we will need to run the same upgrade path validation on the cross channel promotion (ie release a revision tested on edge to beta). 
 