### PR TITLE
Add --help option to microk8s.{enable,disable}

### DIFF
--- a/microk8s-resources/wrappers/microk8s-disable.wrapper
+++ b/microk8s-resources/wrappers/microk8s-disable.wrapper
@@ -4,9 +4,9 @@ export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_6
 export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
 
 if echo "$*" | grep -q -- '--help'; then
-    echo "Usage: $(basename "$0") ADDON..."
+    echo "Usage: $(basename -s.wrapper "$0") ADDON..."
     echo "Disable one or more ADDON included with microk8s"
-    echo "Example: $(basename "$0") dns storage"
+    echo "Example: $(basename -s.wrapper "$0") dns storage"
     echo
     echo "Available addons:"
     echo

--- a/microk8s-resources/wrappers/microk8s-disable.wrapper
+++ b/microk8s-resources/wrappers/microk8s-disable.wrapper
@@ -4,9 +4,10 @@ export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_6
 export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
 
 if echo "$*" | grep -q -- '--help'; then
-    echo "Usage: $(basename -s.wrapper "$0") ADDON..."
+    prog=$(basename -s.wrapper "$0" | tr - .)
+    echo "Usage: $prog ADDON..."
     echo "Disable one or more ADDON included with microk8s"
-    echo "Example: $(basename -s.wrapper "$0") dns storage"
+    echo "Example: $prog dns storage"
     echo
     echo "Available addons:"
     echo

--- a/microk8s-resources/wrappers/microk8s-disable.wrapper
+++ b/microk8s-resources/wrappers/microk8s-disable.wrapper
@@ -3,6 +3,21 @@ export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu"
 export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
 
+if echo "$*" | grep -q -- '--help'; then
+    echo "Usage: $(basename "$0") ADDON..."
+    echo "Disable one or more ADDON included with microk8s"
+    echo "Example: $(basename "$0") dns storage"
+    echo
+    echo "Available addons:"
+    echo
+    actions="$(find "${SNAP}/actions" -name '*.yaml' -or -name 'disable.*.sh')"
+    actions="$(echo "$actions" | sed -e 's/.*[/.]\([^.]*\)\..*/\1/' | sort | uniq)"
+    for action in $actions; do
+        echo "  $action"
+    done
+    exit
+fi
+
 for action in "$@"; do
   # If there is a script to execute for the action $1 run the script and ignore any yamls
   if [ -f "${SNAP}/actions/disable.$action.sh" ]; then

--- a/microk8s-resources/wrappers/microk8s-enable.wrapper
+++ b/microk8s-resources/wrappers/microk8s-enable.wrapper
@@ -4,9 +4,10 @@ export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_6
 export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
 
 if echo "$*" | grep -q -- '--help'; then
-    echo "Usage: $(basename -s.wrapper "$0") ADDON..."
+    prog=$(basename -s.wrapper "$0" | tr - .)
+    echo "Usage: $prog ADDON..."
     echo "Enable one or more ADDON included with microk8s"
-    echo "Example: $(basename -s.wrapper "$0") dns storage"
+    echo "Example: $prog dns storage"
     echo
     echo "Available addons:"
     echo

--- a/microk8s-resources/wrappers/microk8s-enable.wrapper
+++ b/microk8s-resources/wrappers/microk8s-enable.wrapper
@@ -3,6 +3,21 @@ export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu"
 export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
 
+if echo "$*" | grep -q -- '--help'; then
+    echo "Usage: $(basename "$0") ADDON..."
+    echo "Enable one or more ADDON included with microk8s"
+    echo "Example: $(basename "$0") dns storage"
+    echo
+    echo "Available addons:"
+    echo
+    actions="$(find "${SNAP}/actions" -name '*.yaml' -or -name 'enable.*.sh')"
+    actions="$(echo "$actions" | sed -e 's/.*[/.]\([^.]*\)\..*/\1/' | sort | uniq)"
+    for action in $actions; do
+        echo "  $action"
+    done
+    exit
+fi
+
 for action in "$@"; do
   # If there is a script to execute for the $action run the script and ignore any yamls
   if [ -f "${SNAP}/actions/enable.$action.sh" ]; then

--- a/microk8s-resources/wrappers/microk8s-enable.wrapper
+++ b/microk8s-resources/wrappers/microk8s-enable.wrapper
@@ -4,9 +4,9 @@ export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_6
 export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
 
 if echo "$*" | grep -q -- '--help'; then
-    echo "Usage: $(basename "$0") ADDON..."
+    echo "Usage: $(basename -s.wrapper "$0") ADDON..."
     echo "Enable one or more ADDON included with microk8s"
-    echo "Example: $(basename "$0") dns storage"
+    echo "Example: $(basename -s.wrapper "$0") dns storage"
     echo
     echo "Available addons:"
     echo


### PR DESCRIPTION
This provides a way to see at runtime what addons are available, instead of having to go to the repo and look at the README (which could be out of date).

Example output:

```
$ microk8s.enable --help
Usage: microk8s.enable ADDON...
Enable one or more ADDON included with microk8s
Example: microk8s.enable dns storage

Available addons:

  dashboard
  dns
  ingress
  storage
```